### PR TITLE
AutoGluon MultiModal model SageMaker deploy tutorial

### DIFF
--- a/advanced_functionality/autogluon-multimodal-containers/AutoGluon_Multimodal_SageMaker_Containers.ipynb
+++ b/advanced_functionality/autogluon-multimodal-containers/AutoGluon_Multimodal_SageMaker_Containers.ipynb
@@ -1,0 +1,613 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "519a2c14-1ecf-48f6-b6af-debb4a599345",
+   "metadata": {},
+   "source": [
+    "# AutoGluon Multimodal with Deep Learning Containers on SageMaker\n",
+    "\n",
+    "[AutoGluon](https://github.com/awslabs/autogluon) automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications. With just a few lines of code, you can train and deploy high-accuracy deep learning models on tabular, image, and text data.\n",
+    "This example shows how to use AutoGluon-Multimodal with Amazon SageMaker by applying [pre-built deep learning containers](https://github.com/aws/deep-learning-containers/blob/master/available_images.md#autogluon-training-containers)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e373e83-6681-4337-8e4c-69768102ddc0",
+   "metadata": {},
+   "source": [
+    "# Prerequisites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62626ac2-e29e-4e1f-9cfd-cd448cda56fb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!python -m pip install --upgrade pip\n",
+    "!python -m pip install -U 'sagemaker>=2.103.0'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a08649e9-e554-4ffc-8c0c-aac66d6d75b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "import os\n",
+    "import shutil\n",
+    "import urllib\n",
+    "import zipfile\n",
+    "\n",
+    "import boto3\n",
+    "import sagemaker\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sagemaker import utils\n",
+    "from sagemaker.serializers import CSVSerializer\n",
+    "\n",
+    "from ag_model import (\n",
+    "    AutoGluonTraining,\n",
+    "    AutoGluonInferenceModel,\n",
+    "    AutoGluonMultimodalPredictor,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef5ac9cf-8bec-4ea9-af42-4fc15763a393",
+   "metadata": {},
+   "source": [
+    "To access SageMaker to train and deploy models, you need to use an IAM role that has adequate SageMaker and S3 permissions. If `role` is set to `sagemaker.get_execution_role()`, then the default role for the account profile needs to have the required permissions. If a different role is used, the `role` variable can be set to the URI of the intended IAM role. The easiest way to get all the required SageMaker permissions is to use the `AmazonSageMakerFullAccess` policy. But you should note that this is an overly permissive policy, and policies should be scoped down to the minimum required permissions necessary in non-tutorial environments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28e00794-be4d-471f-88dc-49b8c0c1d7ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "boto_session = boto3.session.Session()\n",
+    "sagemaker_client = boto_session.client(\"sagemaker\")\n",
+    "sagemaker_session = sagemaker.session.Session(\n",
+    "    boto_session=boto_session, sagemaker_client=sagemaker_client\n",
+    ")\n",
+    "\n",
+    "region = boto_session.region_name\n",
+    "role = sagemaker.get_execution_role()\n",
+    "\n",
+    "bucket = sagemaker_session.default_bucket()\n",
+    "s3_prefix = f\"autogluon_sm/{utils.sagemaker_timestamp()}\"\n",
+    "output_path = f\"s3://{bucket}/{s3_prefix}/output/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8d4bad6-0203-4a5c-b88d-2f8fcaca1543",
+   "metadata": {},
+   "source": [
+    "# Retrieve Data\n",
+    "\n",
+    "We will use a simplified and subsampled version of the [PetFinder dataset](https://www.kaggle.com/c/petfinder-adoption-prediction) in this tutorial. The task is to predict the animals' adoption rates based on their adoption profile information. In this simplified version, the adoption speed is grouped into two categories: 0(slow) and 1(fast)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b4bc9f6-b285-40fe-81b0-4cb724e1e0f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_data_dir = \"./data\"\n",
+    "data_zip_file = \"https://automl-mm-bench.s3.amazonaws.com/petfinder_for_tutorial.zip\"\n",
+    "\n",
+    "zip_path, _ = urllib.request.urlretrieve(data_zip_file)\n",
+    "with zipfile.ZipFile(zip_path, \"r\") as f:\n",
+    "    f.extractall(local_data_dir)\n",
+    "\n",
+    "dataset_path = local_data_dir + \"/petfinder_for_tutorial\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79c1cd3e-21a5-4bd8-81fc-97eb9ecac6f1",
+   "metadata": {},
+   "source": [
+    "# Train Model On SageMaker\n",
+    "\n",
+    "SageMaker provides documentation on how users can create their own training/inference scripts: [SageMaker Python SDK examples](https://sagemaker.readthedocs.io/en/stable/overview.html#prepare-a-training-script). This tutorial includes scripts that follow the official examples with a few modifications specific to AutoGluon. Here we use the [official AutoGluon Deep Learning Container images](https://github.com/aws/deep-learning-containers/blob/master/available_images.md#autogluon-training-containers) with custom training scripts (see `scripts/` directory). The scripts created for this tutorial allow AutoGluon configuration to be passed as a YAML file (located in `/config` directory). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "675dd946-f3b2-4b86-9e5a-bfa17d6d9d00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_instance_type = \"ml.g4dn.2xlarge\"\n",
+    "\n",
+    "ag = AutoGluonTraining(\n",
+    "    role=role,\n",
+    "    entry_point=\"scripts/multimodal_train.py\",\n",
+    "    region=region,\n",
+    "    instance_count=1,\n",
+    "    instance_type=training_instance_type,\n",
+    "    framework_version=\"0.5.2\",\n",
+    "    py_version=\"py38\",\n",
+    "    base_job_name=\"autogluon-multimodal-train\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ac29cbf-1da5-4a41-9157-3e4e2adbf8b3",
+   "metadata": {},
+   "source": [
+    "Create a GZIP file of training images to upload to S3 alongside the training datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e033df4-76b6-4272-81fd-4b53d4b343c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_tar_filename = shutil.make_archive(\n",
+    "    base_name=\"images\", format=\"gztar\", root_dir=dataset_path, base_dir=\"images\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52f3121f-1f93-4e23-a49d-649bb879fe95",
+   "metadata": {},
+   "source": [
+    "Upload data to S3 for training. The train data, the test data, the compressed file of images, and the config file are all uploaded as separate data input channels to SageMaker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ae5a5a4-7651-4ea6-a362-423c281acdb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_input = ag.sagemaker_session.upload_data(\n",
+    "    path=os.path.join(dataset_path, \"train.csv\"), key_prefix=s3_prefix\n",
+    ")\n",
+    "eval_input = ag.sagemaker_session.upload_data(\n",
+    "    path=os.path.join(dataset_path, \"test.csv\"), key_prefix=s3_prefix\n",
+    ")\n",
+    "image_input = ag.sagemaker_session.upload_data(\n",
+    "    path=os.path.join(\".\", \"images.tar.gz\"), key_prefix=s3_prefix\n",
+    ")\n",
+    "\n",
+    "config_filename = \"config-fast.yaml\"\n",
+    "\n",
+    "config_input = ag.sagemaker_session.upload_data(\n",
+    "    path=os.path.join(\".\", \"config\", config_filename), key_prefix=s3_prefix\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62fbe663-8b3e-48f4-9158-450697b8f75f",
+   "metadata": {},
+   "source": [
+    "## Fit The Model\n",
+    "\n",
+    "Following the configuration and data preparation steps completed above, we can call fit on the SageMaker model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91f4244e-57e9-4f8e-a76a-90cde0260217",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "job_name = utils.unique_name_from_base(\"test-autogluon-image\")\n",
+    "ag.fit(\n",
+    "    {\"config\": config_input, \"train\": train_input, \"test\": eval_input, \"images\": image_input},\n",
+    "    job_name=job_name,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9e1de3b-2d4a-4389-a53c-b17490852756",
+   "metadata": {},
+   "source": [
+    "## Model Export\n",
+    "\n",
+    "AutoGluon models are portable — everything needed to deploy a trained model is in the tarball created by SageMaker. The artifact can be used locally, on EC2/ECS/EKS, or served via SageMaker Inference. Note: This will be a relatively large file because we set `standalone=True` in the training script when saving the trained `MultiModalPredictor`, which includes the `transformers.CLIPModel` and `transformers.AutoModel` in the tar file, so no online environment is needed during inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e6abe4a-f5bd-4335-a27e-66bf8ff03865",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_s3_key = \"/\".join(ag.model_data.split(\"/\")[3:])\n",
+    "sagemaker_session.download_data(path=\".\", bucket=bucket, key_prefix=model_s3_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "234a2b9a-d656-48e2-aac2-c431836f2449",
+   "metadata": {},
+   "source": [
+    "# Endpoint Deployment\n",
+    "\n",
+    "We can now upload the trained AutoGluon model, configure it for inference on SageMaker, and deploy it as an endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22f85fab-366f-490e-83aa-96d3a0fc26fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_name = sagemaker.utils.unique_name_from_base(\"sagemaker-autogluon-serving-trained-model\")\n",
+    "\n",
+    "model_data = sagemaker_session.upload_data(\n",
+    "    path=os.path.join(\".\", \"model.tar.gz\"), key_prefix=f\"{endpoint_name}/models\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf3c158a-8c7a-4b9d-8439-206915a02808",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inference_instance_type = \"ml.g4dn.xlarge\"\n",
+    "\n",
+    "model = AutoGluonInferenceModel(\n",
+    "    model_data=model_data,\n",
+    "    role=role,\n",
+    "    region=region,\n",
+    "    framework_version=\"0.5.2\",\n",
+    "    py_version=\"py38\",\n",
+    "    instance_type=inference_instance_type,\n",
+    "    source_dir=\"scripts\",\n",
+    "    entry_point=\"multimodal_serve.py\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fc26f6f-a04c-41a0-9ce1-bde2561b595e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor = model.deploy(\n",
+    "    initial_instance_count=1, serializer=CSVSerializer(), instance_type=inference_instance_type\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba6d1493-01f8-4e4d-b8bf-45a4e8c361eb",
+   "metadata": {},
+   "source": [
+    "## Predict On Unlabeled Test Data\n",
+    "\n",
+    "Before using the deployed endpoint, we will create a small unlabeled dataset to perform inference on. In order to send records with their respective images to the endpoint we have to choose a serialization method for the images. Here we choose to read the images from disk into a binary buffer and encode the data into ASCII directly in the image column. In the `multimodal_serve.py` script we include the logic to reverse this process: decode the ASCII to bytes, write the bytes to disk, and replace the ASCII column with image paths, which is how AutoGluon represents image features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d74dbe1d-485c-4774-8e61-4e5e28777324",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def path_expander(path, base_folder):\n",
+    "    return os.path.abspath(os.path.join(base_folder, path))\n",
+    "\n",
+    "\n",
+    "def read_image_bytes_and_encode(image_path):\n",
+    "    with open(image_path, \"rb\") as image_fo:\n",
+    "        image_bytes = image_fo.read()\n",
+    "    b64_image = base64.b85encode(image_bytes).decode(\"utf-8\")\n",
+    "\n",
+    "    return b64_image\n",
+    "\n",
+    "\n",
+    "def convert_image_path_to_encoded_bytes_in_dataframe(dataframe, image_column):\n",
+    "    dataframe[image_column] = [\n",
+    "        read_image_bytes_and_encode(path) for path in dataframe[image_column]\n",
+    "    ]\n",
+    "\n",
+    "    return dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4addfcb0-9f13-4311-bbf1-2cc21db3ebbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_col = \"Images\"\n",
+    "label_col = \"AdoptionSpeed\"\n",
+    "\n",
+    "test_data = pd.read_csv(os.path.join(dataset_path, \"test.csv\"), index_col=0)\n",
+    "\n",
+    "test_data[image_col] = test_data[image_col].apply(\n",
+    "    lambda ele: path_expander(ele.split(\";\")[0], base_folder=dataset_path)\n",
+    ")  # Use only first image for tutorial\n",
+    "\n",
+    "test_data_w_serialized_img = convert_image_path_to_encoded_bytes_in_dataframe(test_data, image_col)\n",
+    "test_data_unlabeled_raw = test_data_w_serialized_img.drop(columns=label_col)[:100].to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eedc8434-2579-4bec-926e-d912e24333fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = predictor.predict(\n",
+    "    test_data_unlabeled_raw,\n",
+    "    initial_args={\"Accept\": \"application/x-parquet\", \"ContentType\": \"text/csv\"},\n",
+    ")\n",
+    "\n",
+    "correct_preds = sum(\n",
+    "    pd.DataFrame(preds)[1].round().to_numpy() == test_data[label_col][: len(preds)]\n",
+    ") / len(preds)\n",
+    "\n",
+    "print(f\"{correct_preds} are correct\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9583047f-cf72-44b8-899e-229da29adf9f",
+   "metadata": {},
+   "source": [
+    "## Cleanup Endpoint\n",
+    "\n",
+    "Make sure to remove the inference endpoint after use because the account will be charged the associated SageMaker costs for the instance while it is `InService`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bcbea36-6de4-4088-aa68-789a542e13c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor.delete_endpoint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f090bcb2-dbd9-4dd0-b75c-e5cea09949a2",
+   "metadata": {},
+   "source": [
+    "# Batch Transform\n",
+    "\n",
+    "Deploying a trained model to a hosted endpoint has been available in SageMaker since launch and is a great way to provide real-time predictions to a service like a website or mobile app. If the goal is to generate predictions from a trained model on a large dataset where minimizing latency isn’t a concern, the batch transform functionality may be more appropriate.\n",
+    "\n",
+    "Read more about [Batch Transform](https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f238915-dc5c-40b5-8161-cee4b52a8918",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_name = sagemaker.utils.unique_name_from_base(\n",
+    "    \"sagemaker-autogluon-batch-transform-trained-model\"\n",
+    ")\n",
+    "\n",
+    "model_data = sagemaker_session.upload_data(\n",
+    "    path=os.path.join(\".\", \"model.tar.gz\"), key_prefix=f\"{endpoint_name}/models\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2260278-16c5-4f99-aacd-382f41ae642f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_inference_instance_type = \"ml.g4dn.xlarge\"\n",
+    "\n",
+    "model = AutoGluonInferenceModel(\n",
+    "    model_data=model_data,\n",
+    "    role=role,\n",
+    "    region=region,\n",
+    "    framework_version=\"0.5.2\",\n",
+    "    py_version=\"py38\",\n",
+    "    instance_type=batch_inference_instance_type,\n",
+    "    entry_point=\"multimodal_serve.py\",\n",
+    "    source_dir=\"scripts\",\n",
+    "    predictor_cls=AutoGluonMultimodalPredictor,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6f0193d-9b7d-4053-829f-ab80e983a5f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transformer = model.transformer(\n",
+    "    instance_count=1,\n",
+    "    instance_type=batch_inference_instance_type,\n",
+    "    strategy=\"MultiRecord\",\n",
+    "    max_payload=6,\n",
+    "    max_concurrent_transforms=1,\n",
+    "    output_path=output_path,\n",
+    "    accept=\"application/json\",\n",
+    "    assemble_with=\"Line\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a26385bf-4c49-4b48-bfee-a1b1fcedb638",
+   "metadata": {},
+   "source": [
+    "Prepare batch of test data for batch transform on SageMaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaca4642-1828-4bda-a492-14efb43b1a9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_data_for_batch_filename = \"test_data_sample_no_label_no_header.csv\"\n",
+    "batch_sample_size = 10\n",
+    "\n",
+    "test_data_sample_for_batch = test_data.drop(label_col, axis=1)[:batch_sample_size]\n",
+    "test_data_sample_for_batch.to_csv(\n",
+    "    os.path.join(dataset_path, test_data_for_batch_filename), header=False, index=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9bfef44-9c52-49f7-a3ac-00f4b4a4de4d",
+   "metadata": {},
+   "source": [
+    "Upload data to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "563a8db7-58de-4883-be94-25ea1101c6a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_input_batch = transformer.sagemaker_session.upload_data(\n",
+    "    path=os.path.join(dataset_path, test_data_for_batch_filename), key_prefix=s3_prefix\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4238716a-05a0-4593-9ef7-36b9ca33ef5b",
+   "metadata": {},
+   "source": [
+    "Call transform on data batch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32b09e21-4245-4d30-95ce-4e3c39656fec",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "transformer.transform(\n",
+    "    test_input_batch,\n",
+    "    split_type=\"Line\",\n",
+    "    content_type=\"text/csv\",\n",
+    ")\n",
+    "\n",
+    "transformer.wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ede66cb2-eec0-4b0e-b070-c844780bd6e1",
+   "metadata": {},
+   "source": [
+    "Download batch transform outputs and compute scores"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5708f14-007d-47b5-94d5-19228fb61636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!aws s3 cp {transformer.output_path[:-1]}/{test_data_for_batch_filename}.out ."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98efef5a-0d1c-4334-ace3-888e60b535d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_predictions = pd.read_json(f\"{test_data_for_batch_filename}.out\")\n",
+    "\n",
+    "correct_batch_preds = sum(\n",
+    "    batch_predictions[1].round().to_numpy() == test_data[label_col][: len(batch_predictions)]\n",
+    ") / len(batch_predictions)\n",
+    "\n",
+    "print(f\"{correct_batch_preds} are correct\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ff4f212-2a4d-45b5-943f-2b75a72140e2",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "\n",
+    "In this tutorial you trained a MultiModal AutoGluon model and explored multiple to deploy it using SageMaker. Note that all the demonstrated functionalities (training, endpoint inference, batch inference) can be leveraged independently (i.e. train locally, deploy to SageMaker, or vice versa).\n",
+    "\n",
+    "Next steps:\n",
+    "- [Learn more](https://auto.gluon.ai/) about AutoGluon\n",
+    "- Explore the AutoGluon [tutorials](https://auto.gluon.ai/stable/tutorials/index.html)\n",
+    "- Explore [SageMaker inference documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/deploy-model.html)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/advanced_functionality/autogluon-multimodal-containers/README.md
+++ b/advanced_functionality/autogluon-multimodal-containers/README.md
@@ -1,0 +1,6 @@
+<img src="https://user-images.githubusercontent.com/16392542/77208906-224aa500-6aba-11ea-96bd-e81806074030.png" width="350">
+
+# AutoGluon Multimodal with Amazon SageMaker
+
+[AutoGluon](https://github.com/awslabs/autogluon) automates machine learning tasks enabling you to easily achieve strong predictive performance in your applications. With just a few lines of code, you can train and deploy high-accuracy deep learning models on tabular, image, and text data.
+This example shows how to use AutoGluon-Multimodal with Amazon SageMaker by applying [pre-built deep learning containers](https://github.com/aws/deep-learning-containers/blob/master/available_images.md#autogluon-training-containers).

--- a/advanced_functionality/autogluon-multimodal-containers/ag_model.py
+++ b/advanced_functionality/autogluon-multimodal-containers/ag_model.py
@@ -1,0 +1,89 @@
+from sagemaker.estimator import Framework
+from sagemaker.predictor import Predictor
+from sagemaker.mxnet import MXNetModel
+from sagemaker.mxnet.model import MXNetPredictor
+from sagemaker import utils
+from sagemaker import image_uris
+from sagemaker.serializers import CSVSerializer
+from sagemaker.deserializers import StringDeserializer
+
+
+class AutoGluonTraining(Framework):
+    def __init__(
+        self,
+        entry_point,
+        region,
+        framework_version,
+        py_version,
+        instance_type,
+        source_dir=None,
+        hyperparameters=None,
+        **kwargs,
+    ):
+        self.framework_version = framework_version
+        self.py_version = py_version
+        self.image_uri = image_uris.retrieve(
+            "autogluon",
+            region=region,
+            version=framework_version,
+            py_version=py_version,
+            image_scope="training",
+            instance_type=instance_type,
+        )
+        super().__init__(
+            entry_point,
+            source_dir,
+            hyperparameters,
+            framework_version=framework_version,
+            instance_type=instance_type,
+            image_uri=self.image_uri,
+            **kwargs,
+        )
+
+    def _configure_distribution(self, distributions):
+        return
+
+    def create_model(
+        self,
+        model_server_workers=None,
+        role=None,
+        vpc_config_override=None,
+        entry_point=None,
+        source_dir=None,
+        dependencies=None,
+        image_name=None,
+        **kwargs,
+    ):
+        return None
+
+
+class AutoGluonMultimodalPredictor(Predictor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args, serializer=CSVSerializer(), deserializer=StringDeserializer(), **kwargs
+        )
+
+
+class AutoGluonInferenceModel(MXNetModel):
+    def __init__(
+        self,
+        model_data,
+        role,
+        entry_point,
+        region,
+        framework_version,
+        py_version,
+        instance_type,
+        **kwargs,
+    ):
+        image_uri = image_uris.retrieve(
+            "autogluon",
+            region=region,
+            version=framework_version,
+            py_version=py_version,
+            image_scope="inference",
+            instance_type=instance_type,
+        )
+        super().__init__(
+            model_data, role, entry_point, image_uri=image_uri, framework_version="1.8.0", **kwargs
+        )

--- a/advanced_functionality/autogluon-multimodal-containers/config/config-fast.yaml
+++ b/advanced_functionality/autogluon-multimodal-containers/config/config-fast.yaml
@@ -1,0 +1,11 @@
+# AutoGluon Predictor constructor arguments
+ag_predictor_args:
+  label: AdoptionSpeed
+  problem_type: binary
+  eval_metric: accuracy
+
+# AutoGluon Predictor.fit arguments
+ag_fit_args:
+    time_limit: 300
+
+output_prediction_format: csv  # predictions output format: csv or parquet

--- a/advanced_functionality/autogluon-multimodal-containers/scripts/multimodal_serve.py
+++ b/advanced_functionality/autogluon-multimodal-containers/scripts/multimodal_serve.py
@@ -1,0 +1,60 @@
+import base64
+import hashlib
+import json
+from io import BytesIO, StringIO
+
+import pandas as pd
+from PIL import Image
+
+from autogluon.multimodal import MultiModalPredictor
+
+
+def _decode_and_save_base85_image(image_b85):
+    """saves Base65 encoded image to disk and returns unique name"""
+
+    image_bytes = base64.b85decode(image_b85)
+    image_hash = hashlib.md5(image_bytes).hexdigest()
+    image_name = f"image_{image_hash}.png"
+    image = Image.open(BytesIO(image_bytes))
+    image.save(image_name)
+
+    return image_name
+
+
+def model_fn(model_dir):
+    """loads model from previously saved artifact"""
+
+    model = MultiModalPredictor.load(model_dir)
+    globals()["column_names"] = [
+        column_name
+        for column_name in model._column_types.keys()
+        if column_name != model._label_column
+    ]
+
+    return model
+
+
+def transform_fn(model, request_body, input_content_type, output_content_type="application/json"):
+
+    if input_content_type != "text/csv":
+        raise Exception(f"{input_content_type} content type not supported.")
+
+    buf = StringIO(request_body)
+    data = pd.read_csv(buf, header=None)
+
+    if len(data.columns) != len(column_names):
+        raise Exception(
+            f"Invalid data format. Input data has {len(data.columns)} while the model expects {len(column_names)}."
+        )
+
+    data.columns = column_names
+
+    for column_name, column_type in model._column_types.items():
+        if column_type in ("image_path", "image"):
+            data[column_name] = [
+                _decode_and_save_base85_image(encoded_image) for encoded_image in data[column_name]
+            ]
+
+    prediction_proba = model.predict_proba(data)
+
+    return json.dumps(prediction_proba.to_numpy().tolist()), output_content_type

--- a/advanced_functionality/autogluon-multimodal-containers/scripts/multimodal_train.py
+++ b/advanced_functionality/autogluon-multimodal-containers/scripts/multimodal_train.py
@@ -1,0 +1,83 @@
+import argparse
+import os
+import shutil
+from pprint import pprint
+
+import yaml
+import pandas as pd
+
+from autogluon.multimodal import MultiModalPredictor
+
+
+def get_input_path(path):
+    file = os.listdir(path)[0]
+    if len(os.listdir(path)) > 1:
+        print(f"WARN: more than one file is found in {path} directory")
+    print(f"Using {file}")
+    filename = f"{path}/{file}"
+    return filename
+
+
+if __name__ == "__main__":
+    # Disable Autotune
+    os.environ["MXNET_CUDNN_AUTOTUNE_DEFAULT"] = "0"
+
+    # ------------------------------------------------------------ Args parsing
+    print("Starting AG")
+    parser = argparse.ArgumentParser()
+
+    # Data, model, and output directories
+    parser.add_argument("--output-data-dir", type=str, default=os.environ.get("SM_OUTPUT_DATA_DIR"))
+    parser.add_argument("--model-dir", type=str, default=os.environ.get("SM_MODEL_DIR"))
+    parser.add_argument("--n_gpus", type=str, default=os.environ.get("SM_NUM_GPUS"))
+    parser.add_argument("--training_dir", type=str, default=os.environ.get("SM_CHANNEL_TRAIN"))
+    parser.add_argument(
+        "--test_dir", type=str, required=False, default=os.environ.get("SM_CHANNEL_TEST")
+    )
+    parser.add_argument("--images_dir", type=str, default=os.environ.get("SM_CHANNEL_IMAGES"))
+    parser.add_argument("--ag_config", type=str, default=os.environ.get("SM_CHANNEL_CONFIG"))
+
+    args, _ = parser.parse_known_args()
+
+    print(f"Args: {args}")
+
+    # See SageMaker-specific environment variables: https://sagemaker.readthedocs.io/en/stable/overview.html#prepare-a-training-script
+    os.makedirs(args.output_data_dir, mode=0o755, exist_ok=True)
+
+    config_file = get_input_path(args.ag_config)
+    with open(config_file) as f:
+        config = yaml.safe_load(f)  # AutoGluon-specific config
+
+    if args.n_gpus:
+        config["num_gpus"] = int(args.n_gpus)
+
+    print("Running training job with the config:")
+    pprint(config)
+
+    # ---------------------------------------------------------------- Training
+
+    save_path = os.path.normpath(args.model_dir)
+
+    train_file = get_input_path(args.training_dir)
+    train_data = pd.read_csv(train_file, index_col=0)
+
+    ag_predictor_args = config["ag_predictor_args"]
+    ag_predictor_args["path"] = save_path
+    ag_fit_args = config["ag_fit_args"]
+
+    if args.images_dir:
+        image_compressed_file = get_input_path(args.images_dir)
+        shutil.unpack_archive(image_compressed_file)
+
+    predictor = MultiModalPredictor(**ag_predictor_args).fit(train_data, **ag_fit_args)
+    predictor.save(path=save_path + os.path.sep, standalone=True)
+
+    # --------------------------------------------------------------- Inference
+
+    if args.test_dir:
+        test_file = get_input_path(args.test_dir)
+        test_data = pd.read_csv(test_file)
+
+        # Predictions
+        y_pred_proba = predictor.predict_proba(test_data)
+        y_pred_proba.to_csv(f"{args.output_data_dir}/predictions.csv")

--- a/advanced_functionality/autogluon-tabular-containers/AutoGluon_Tabular_SageMaker_Containers.ipynb
+++ b/advanced_functionality/autogluon-tabular-containers/AutoGluon_Tabular_SageMaker_Containers.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "# Ensure autogluon images information is available in SageMaker Python SDK\n",
-    "!pip install -q -U 'sagemaker>=2.80'"
+    "!pip install -q -U 'sagemaker>=2.103.0'"
    ]
   },
   {
@@ -186,7 +186,7 @@
     "    region=region,\n",
     "    instance_count=1,\n",
     "    instance_type=\"ml.m5.2xlarge\",\n",
-    "    framework_version=\"0.4\",\n",
+    "    framework_version=\"0.5.2\",\n",
     "    py_version=\"py38\",\n",
     "    base_job_name=\"autogluon-tabular-train\",\n",
     ")"
@@ -371,7 +371,7 @@
     "    model_data=model_data,\n",
     "    role=role,\n",
     "    region=region,\n",
-    "    framework_version=\"0.4\",\n",
+    "    framework_version=\"0.5.2\",\n",
     "    py_version=\"py38\",\n",
     "    instance_type=instance_type,\n",
     "    source_dir=\"scripts\",\n",
@@ -582,7 +582,7 @@
     "    model_data=model_data,\n",
     "    role=role,\n",
     "    region=region,\n",
-    "    framework_version=\"0.4\",\n",
+    "    framework_version=\"0.5.2\",\n",
     "    py_version=\"py38\",\n",
     "    instance_type=instance_type,\n",
     "    entry_point=\"tabular_serve-batch.py\",\n",


### PR DESCRIPTION
Note: This PR is local to my forked repo and is intended for review by the AutoGluon devs before I make an official PR to the `aws/amazon-sagemaker-examples` repo.

### Description
This set of changes introduces a tutorial for using SageMaker to train and deploy the AutoGluon MutiModal predictor using the `autogluon-training-containers`. It is heavily influenced by the [autogluon-tabular-containers](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/autogluon-tabular-containers) tutorial.

### Outline
- The main contribution is the [tutorial notebook](https://github.com/gidler/amazon-sagemaker-examples/compare/main...gidler:amazon-sagemaker-examples:autogluon_automm_tutorial?expand=1#diff-92d0cdfd683b3f67a1faad6be825547b35523606812bf8bf89ab52e270fe6cb5). It is similar to the `autogluon-tabular-containers` [tutorial notebook](https://github.com/aws/amazon-sagemaker-examples/blob/main/advanced_functionality/autogluon-tabular-containers/AutoGluon_Tabular_SageMaker_Containers.ipynb) but has significant changes throughout related to MultiModal data and prediction that require review from the AutoGluon team.
- [README.md](advanced_functionality/autogluon-multimodal-containers/README.md) is a small tweak from the `autogluon-tabular-containers` [README.md](https://github.com/aws/amazon-sagemaker-examples/blob/main/advanced_functionality/autogluon-tabular-containers/README.md) to reflect the MultiModal nature of the tutorial.
- [ag_model.py](advanced_functionality/autogluon-multimodal-containers/ag_model.py) is a close adaption of the [equivalent file](https://github.com/aws/amazon-sagemaker-examples/blob/main/advanced_functionality/autogluon-tabular-containers/ag_model.py) from the [autogluon-tabular-containers](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/autogluon-tabular-containers) tutorial with name changes to reflect the use of the MultiModal predictor.
- The [train](advanced_functionality/autogluon-multimodal-containers/scripts/multimodal_train.py) and [serve](advanced_functionality/autogluon-multimodal-containers/scripts/multimodal_serve.py) scripts are similar to the [scripts](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/autogluon-tabular-containers/scripts) in `autogluon-tabular-containers` with changes for MultiModal data and pythonic updates.
- The [config file](advanced_functionality/autogluon-multimodal-containers/config/config-fast.yaml) is a yaml file that contains arguments for the predictor constructor, for the `fit()` call, and for the Sagemaker model.

P.S. When I submit this PR to the main aws repo, I plan to also update the version numbers in the [autogluon-tabular-containers](https://github.com/aws/amazon-sagemaker-examples/tree/main/advanced_functionality/autogluon-tabular-containers) tutorial.
